### PR TITLE
Standings page

### DIFF
--- a/backend/app/routes/nba.py
+++ b/backend/app/routes/nba.py
@@ -14,6 +14,7 @@ from ..services.nba_service import (
     get_team_last_games,
     get_upcoming_games,
     get_today_games,
+    get_standings,
 )
 
 # Blueprint for NBA-related routes; mounted by the app factory at /api/v1/nba
@@ -74,3 +75,14 @@ def nba_upcoming():
 def nba_today():
     """List NBA games for today."""
     return get_today_games()
+
+
+@bp.get("/standings")
+def nba_standings():
+    """Get NBA standings.
+    
+    Query params:
+        season (str): Optional season year (e.g., 2024)
+    """
+    season = request.args.get("season")
+    return get_standings(season=season)

--- a/backend/app/routes/nfl.py
+++ b/backend/app/routes/nfl.py
@@ -13,6 +13,7 @@ from ..services.nfl_service import (
     get_box_score,
     get_upcoming_games,
     get_today_games,
+    get_standings,
 )
 
 # Blueprint for NFL routes; mounted at /api/v1/nfl
@@ -50,3 +51,14 @@ def nfl_upcoming():
 def nfl_today():
     """List NFL games for today."""
     return get_today_games()
+
+
+@bp.get("/standings")
+def nfl_standings():
+    """Get NFL standings.
+    
+    Query params:
+        season (str): Optional season year (e.g., 2024)
+    """
+    season = request.args.get("season")
+    return get_standings(season=season)

--- a/backend/app/routes/soccer.py
+++ b/backend/app/routes/soccer.py
@@ -13,6 +13,7 @@ from ..services.soccer_service import (
     get_box_score,
     get_upcoming_games,
     get_today_games,
+    get_standings,
 )
 
 # Blueprint for Soccer routes; mounted at /api/v1/soccer
@@ -54,3 +55,16 @@ def soccer_today():
     """List soccer games for today for a specific league."""
     league = request.args.get("league", "MLS")
     return get_today_games(league=league)
+
+
+@bp.get("/standings")
+def soccer_standings():
+    """Get soccer standings for a given league.
+    
+    Query params:
+        league (str): League key (MLS, EPL, LaLiga) - default MLS
+        season (str): Optional season year (e.g., 2024)
+    """
+    league = request.args.get("league", "MLS")
+    season = request.args.get("season")
+    return get_standings(league=league, season=season)

--- a/backend/app/services/nba_service.py
+++ b/backend/app/services/nba_service.py
@@ -8,11 +8,13 @@ Purpose: Thin service layer for NBA data using the python package `nba_api` (whi
 
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
+import requests
 
 from nba_api.stats.endpoints import (
     boxscoretraditionalv2,
     boxscoresummaryv2,
     leaguegamelog,
+    leaguestandingsv3,
     scoreboardv2,
     teamgamelog,
 )
@@ -217,3 +219,163 @@ def get_historical_games(start_date=None, end_date=None, season=None, team_id=No
         return data
     except Exception as e:
         return {"error": str(e), "data": [], "meta": {"page": page, "per_page": per_page, "total": 0}}
+
+
+def _get_nba_team_logos():
+    """Get NBA team logos mapping.
+    
+    Returns static mapping since ESPN API may not be accessible from backend.
+    Returns:
+        Dictionary mapping team slugs to logo URLs
+    """
+    # Static mapping of team slugs to ESPN logo URLs
+    logo_map = {
+        "atlanta-hawks": "https://a.espncdn.com/i/teamlogos/nba/500/atl.png",
+        "boston-celtics": "https://a.espncdn.com/i/teamlogos/nba/500/bos.png",
+        "brooklyn-nets": "https://a.espncdn.com/i/teamlogos/nba/500/bkn.png",
+        "charlotte-hornets": "https://a.espncdn.com/i/teamlogos/nba/500/cha.png",
+        "chicago-bulls": "https://a.espncdn.com/i/teamlogos/nba/500/chi.png",
+        "cleveland-cavaliers": "https://a.espncdn.com/i/teamlogos/nba/500/cle.png",
+        "dallas-mavericks": "https://a.espncdn.com/i/teamlogos/nba/500/dal.png",
+        "denver-nuggets": "https://a.espncdn.com/i/teamlogos/nba/500/den.png",
+        "detroit-pistons": "https://a.espncdn.com/i/teamlogos/nba/500/det.png",
+        "golden-state-warriors": "https://a.espncdn.com/i/teamlogos/nba/500/gs.png",
+        "houston-rockets": "https://a.espncdn.com/i/teamlogos/nba/500/hou.png",
+        "indiana-pacers": "https://a.espncdn.com/i/teamlogos/nba/500/ind.png",
+        "la-clippers": "https://a.espncdn.com/i/teamlogos/nba/500/lac.png",
+        "los-angeles-lakers": "https://a.espncdn.com/i/teamlogos/nba/500/lal.png",
+        "memphis-grizzlies": "https://a.espncdn.com/i/teamlogos/nba/500/mem.png",
+        "miami-heat": "https://a.espncdn.com/i/teamlogos/nba/500/mia.png",
+        "milwaukee-bucks": "https://a.espncdn.com/i/teamlogos/nba/500/mil.png",
+        "minnesota-timberwolves": "https://a.espncdn.com/i/teamlogos/nba/500/min.png",
+        "new-orleans-pelicans": "https://a.espncdn.com/i/teamlogos/nba/500/no.png",
+        "new-york-knicks": "https://a.espncdn.com/i/teamlogos/nba/500/ny.png",
+        "oklahoma-city-thunder": "https://a.espncdn.com/i/teamlogos/nba/500/okc.png",
+        "orlando-magic": "https://a.espncdn.com/i/teamlogos/nba/500/orl.png",
+        "philadelphia-76ers": "https://a.espncdn.com/i/teamlogos/nba/500/phi.png",
+        "phoenix-suns": "https://a.espncdn.com/i/teamlogos/nba/500/phx.png",
+        "portland-trail-blazers": "https://a.espncdn.com/i/teamlogos/nba/500/por.png",
+        "sacramento-kings": "https://a.espncdn.com/i/teamlogos/nba/500/sac.png",
+        "san-antonio-spurs": "https://a.espncdn.com/i/teamlogos/nba/500/sa.png",
+        "toronto-raptors": "https://a.espncdn.com/i/teamlogos/nba/500/tor.png",
+        "utah-jazz": "https://a.espncdn.com/i/teamlogos/nba/500/utah.png",
+        "washington-wizards": "https://a.espncdn.com/i/teamlogos/nba/500/wsh.png",
+        # Also add lowercase slug versions
+        "hawks": "https://a.espncdn.com/i/teamlogos/nba/500/atl.png",
+        "celtics": "https://a.espncdn.com/i/teamlogos/nba/500/bos.png",
+        "nets": "https://a.espncdn.com/i/teamlogos/nba/500/bkn.png",
+        "hornets": "https://a.espncdn.com/i/teamlogos/nba/500/cha.png",
+        "bulls": "https://a.espncdn.com/i/teamlogos/nba/500/chi.png",
+        "cavaliers": "https://a.espncdn.com/i/teamlogos/nba/500/cle.png",
+        "mavericks": "https://a.espncdn.com/i/teamlogos/nba/500/dal.png",
+        "nuggets": "https://a.espncdn.com/i/teamlogos/nba/500/den.png",
+        "pistons": "https://a.espncdn.com/i/teamlogos/nba/500/det.png",
+        "warriors": "https://a.espncdn.com/i/teamlogos/nba/500/gs.png",
+        "rockets": "https://a.espncdn.com/i/teamlogos/nba/500/hou.png",
+        "pacers": "https://a.espncdn.com/i/teamlogos/nba/500/ind.png",
+        "clippers": "https://a.espncdn.com/i/teamlogos/nba/500/lac.png",
+        "lakers": "https://a.espncdn.com/i/teamlogos/nba/500/lal.png",
+        "grizzlies": "https://a.espncdn.com/i/teamlogos/nba/500/mem.png",
+        "heat": "https://a.espncdn.com/i/teamlogos/nba/500/mia.png",
+        "bucks": "https://a.espncdn.com/i/teamlogos/nba/500/mil.png",
+        "timberwolves": "https://a.espncdn.com/i/teamlogos/nba/500/min.png",
+        "pelicans": "https://a.espncdn.com/i/teamlogos/nba/500/no.png",
+        "knicks": "https://a.espncdn.com/i/teamlogos/nba/500/ny.png",
+        "thunder": "https://a.espncdn.com/i/teamlogos/nba/500/okc.png",
+        "magic": "https://a.espncdn.com/i/teamlogos/nba/500/orl.png",
+        "76ers": "https://a.espncdn.com/i/teamlogos/nba/500/phi.png",
+        "suns": "https://a.espncdn.com/i/teamlogos/nba/500/phx.png",
+        "trail-blazers": "https://a.espncdn.com/i/teamlogos/nba/500/por.png",
+        "blazers": "https://a.espncdn.com/i/teamlogos/nba/500/por.png",
+        "kings": "https://a.espncdn.com/i/teamlogos/nba/500/sac.png",
+        "spurs": "https://a.espncdn.com/i/teamlogos/nba/500/sa.png",
+        "raptors": "https://a.espncdn.com/i/teamlogos/nba/500/tor.png",
+        "jazz": "https://a.espncdn.com/i/teamlogos/nba/500/utah.png",
+        "wizards": "https://a.espncdn.com/i/teamlogos/nba/500/wsh.png",
+    }
+    
+    return logo_map
+
+
+def get_standings(season: Optional[str] = None):
+    """Fetch NBA standings using LeagueStandingsV3.
+    
+    Args:
+        season: Optional season string (e.g., '2024' or '2024-25')
+    
+    Returns:
+        Dictionary containing standings data organized by conference and division
+    """
+    try:
+        season_fmt = _season_to_nba_format(season)
+        standings_data = leaguestandingsv3.LeagueStandingsV3(
+            league_id="00",
+            season=season_fmt if season_fmt else "2025-26",
+            season_type="Regular Season"
+        ).get_normalized_dict()
+        
+        standings = standings_data.get("Standings", [])
+        
+        # Fetch team logos from ESPN
+        logo_map = _get_nba_team_logos()
+        
+        # Organize by conference and division
+        eastern_conf = []
+        western_conf = []
+        
+        for team in standings:
+            team_abbreviation = team.get("TeamAbbreviation") or team.get("TeamSlug", "").upper()
+            team_slug = team.get("TeamSlug", "")
+            # Get logo from ESPN API - try multiple variations
+            team_logo = (logo_map.get(team_abbreviation) or 
+                        logo_map.get(team_abbreviation.lower()) or
+                        logo_map.get(team_slug) or 
+                        logo_map.get(team_slug.lower()) or
+                        logo_map.get(team_slug.upper()))
+            
+            if not team_logo:
+                print(f"No logo found for team: {team.get('TeamCity')} {team.get('TeamName')} (abbr: {team_abbreviation}, slug: {team_slug})")
+            
+            team_data = {
+                "team_id": team.get("TeamID"),
+                "team_name": team.get("TeamName"),
+                "team_city": team.get("TeamCity"),
+                "team_abbreviation": team_abbreviation,
+                "team_logo": team_logo,
+                "team_slug": team.get("TeamSlug"),
+                "conference": team.get("Conference"),
+                "division": team.get("Division"),
+                "wins": team.get("WINS"),
+                "losses": team.get("LOSSES"),
+                "win_pct": team.get("WinPCT"),
+                "conference_rank": team.get("ConferenceRecord"),
+                "division_rank": team.get("DivisionRank"),
+                "home_record": team.get("HOME"),
+                "road_record": team.get("ROAD"),
+                "last_10": team.get("L10"),
+                "streak": team.get("CurrentStreak"),
+                "games_back": team.get("ConferenceGamesBack")
+            }
+            
+            if team.get("Conference") == "East":
+                eastern_conf.append(team_data)
+            else:
+                western_conf.append(team_data)
+        
+        # Sort by wins descending
+        eastern_conf.sort(key=lambda x: (x["wins"], x["win_pct"]), reverse=True)
+        western_conf.sort(key=lambda x: (x["wins"], x["win_pct"]), reverse=True)
+        
+        return {
+            "league": "NBA",
+            "season": season_fmt if season_fmt else "2025-26",
+            "eastern_conference": eastern_conf,
+            "western_conference": western_conf
+        }
+    except Exception as e:
+        return {
+            "error": str(e),
+            "league": "NBA",
+            "eastern_conference": [],
+            "western_conference": []
+        }

--- a/backend/app/services/nfl_service.py
+++ b/backend/app/services/nfl_service.py
@@ -13,6 +13,7 @@ import requests
 # ESPN public API endpoints (undocumented but widely used and publicly accessible)
 SCOREBOARD = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard"
 EVENT = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/summary"
+STANDINGS = "https://site.api.espn.com/apis/v2/sports/football/nfl/standings"
 
 
 def _get(url: str, params: Optional[Dict[str, Any]] = None):
@@ -165,3 +166,136 @@ def get_historical_games(start_date=None, end_date=None, season=None, team_id=No
         
     except Exception as e:
         return {"error": str(e), "events": [], "meta": {"page": page, "per_page": per_page, "total": 0}}
+
+
+def get_standings(season: Optional[str] = None):
+    """Fetch NFL standings from ESPN API.
+    
+    Args:
+        season: Optional season year (e.g., '2024')
+    
+    Returns:
+        Dictionary containing standings data organized by conference and division
+    """
+    try:
+        params = {}
+        if season:
+            params["season"] = season
+            
+        data = _get(STANDINGS, params)
+        
+        # ESPN API returns data with children array directly at top level
+        afc_standings = []
+        nfc_standings = []
+        
+        # Get the children array (conferences)
+        conferences = data.get("children", [])
+        
+        if not conferences:
+            return {
+                "error": "No children data in API response",
+                "league": "NFL",
+                "afc_standings": [],
+                "nfc_standings": []
+            }
+        
+        # Process each conference
+        for conference in conferences:
+            conference_name = conference.get("name", "")
+            conference_abbr = conference.get("abbreviation", "")
+            
+            # Check if this conference has divisions as children
+            divisions = conference.get("children", [])
+            
+            if divisions:
+                # Process divisions within conference
+                for division in divisions:
+                    division_name = division.get("name", "")
+                    standings_entries = division.get("standings", {}).get("entries", [])
+                    
+                    for entry in standings_entries:
+                        team = entry.get("team", {})
+                        stats = entry.get("stats", [])
+                        
+                        # Parse stats array into a dictionary
+                        stats_dict = {}
+                        for stat in stats:
+                            stat_name = stat.get("name", "").lower().replace(" ", "_")
+                            stats_dict[stat_name] = stat.get("value")
+                        
+                        team_data = {
+                            "team_id": team.get("id"),
+                            "team_name": team.get("displayName"),
+                            "team_abbreviation": team.get("abbreviation"),
+                            "team_logo": team.get("logos", [{}])[0].get("href") if team.get("logos") else None,
+                            "conference": conference_name,
+                            "division": division_name,
+                            "wins": int(stats_dict.get("wins", 0)),
+                            "losses": int(stats_dict.get("losses", 0)),
+                            "ties": int(stats_dict.get("ties", 0)),
+                            "win_pct": float(stats_dict.get("winpercent", 0)),
+                            "points_for": float(stats_dict.get("pointsfor", 0)),
+                            "points_against": float(stats_dict.get("pointsagainst", 0)),
+                            "point_differential": float(stats_dict.get("pointdifferential", 0)),
+                            "streak": stats_dict.get("streak"),
+                            "division_rank": int(stats_dict.get("divisionrank", 0)),
+                            "conference_rank": int(stats_dict.get("conferencerank", 0)),
+                            "playoff_seed": int(stats_dict.get("playoffseed", 0))
+                        }
+                        
+                        if "AFC" in conference_name or "AFC" in conference_abbr:
+                            afc_standings.append(team_data)
+                        elif "NFC" in conference_name or "NFC" in conference_abbr:
+                            nfc_standings.append(team_data)
+            else:
+                # Fallback: process standings entries directly under conference
+                standings_entries = conference.get("standings", {}).get("entries", [])
+                
+                for entry in standings_entries:
+                    team = entry.get("team", {})
+                    stats = entry.get("stats", [])
+                    
+                    # Parse stats array into a dictionary
+                    stats_dict = {}
+                    for stat in stats:
+                        stat_name = stat.get("name", "").lower().replace(" ", "_")
+                        stats_dict[stat_name] = stat.get("value")
+                    
+                    team_data = {
+                        "team_id": team.get("id"),
+                        "team_name": team.get("displayName"),
+                        "team_abbreviation": team.get("abbreviation"),
+                        "team_logo": team.get("logos", [{}])[0].get("href") if team.get("logos") else None,
+                        "conference": conference_name,
+                        "division": None,  # No division info available
+                        "wins": int(stats_dict.get("wins", 0)),
+                        "losses": int(stats_dict.get("losses", 0)),
+                        "ties": int(stats_dict.get("ties", 0)),
+                        "win_pct": float(stats_dict.get("winpercent", 0)),
+                        "points_for": float(stats_dict.get("pointsfor", 0)),
+                        "points_against": float(stats_dict.get("pointsagainst", 0)),
+                        "point_differential": float(stats_dict.get("pointdifferential", 0)),
+                        "streak": stats_dict.get("streak"),
+                        "division_rank": int(stats_dict.get("divisionrank", 0)),
+                        "conference_rank": int(stats_dict.get("conferencerank", 0)),
+                        "playoff_seed": int(stats_dict.get("playoffseed", 0))
+                    }
+                    
+                    if "AFC" in conference_name or "AFC" in conference_abbr:
+                        afc_standings.append(team_data)
+                    elif "NFC" in conference_name or "NFC" in conference_abbr:
+                        nfc_standings.append(team_data)
+        
+        return {
+            "league": "NFL",
+            "season": season if season else str(datetime.utcnow().year),
+            "afc_standings": afc_standings,
+            "nfc_standings": nfc_standings
+        }
+    except Exception as e:
+        return {
+            "error": str(e),
+            "league": "NFL",
+            "afc_standings": [],
+            "nfc_standings": []
+        }

--- a/frontend/src/app/(user)/standings/page.tsx
+++ b/frontend/src/app/(user)/standings/page.tsx
@@ -1,0 +1,486 @@
+/*
+    File: frontend/src/app/(user)/standings/page.tsx
+    Created: 2025-10-17
+    
+    Description: Standings page displaying current standings for NBA, NFL, and Soccer leagues
+    with unique visuals, animations, and playoff bracket support.
+*/
+"use client";
+import React, { useState, useEffect } from 'react';
+import { getNBAStandings, getNFLStandings, getSoccerStandings } from '@/backend_methods/standings_methods';
+import { Trophy, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+
+type SportKey = 'NBA' | 'NFL' | 'MLS';
+
+type NBATeam = {
+    team_id: number;
+    team_name: string;
+    team_city: string;
+    team_abbreviation: string;
+    team_logo: string;
+    conference: string;
+    division: string;
+    wins: number;
+    losses: number;
+    win_pct: number;
+    home_record: string;
+    road_record: string;
+    last_10: string;
+    streak: string | number | null;
+    games_back: number;
+};
+
+type NFLTeam = {
+    team_id: string;
+    team_name: string;
+    team_abbreviation: string;
+    team_logo: string;
+    conference: string;
+    division: string | null;
+    wins: number;
+    losses: number;
+    ties: number;
+    win_pct: number;
+    points_for: number;
+    points_against: number;
+    point_differential: number;
+    streak: string | number | null;
+    division_rank: number;
+    conference_rank: number;
+    playoff_seed: number;
+};
+
+type SoccerTeam = {
+    team_id: string;
+    team_name: string;
+    team_abbreviation: string;
+    team_logo: string;
+    group: string;
+    rank: number;
+    wins: number;
+    losses: number;
+    draws: number;
+    points: number;
+    goals_for: number;
+    goals_against: number;
+    goal_differential: number;
+    games_played: number;
+};
+
+const SportsFilter: React.FC<{
+    sports: SportKey[];
+    activeSport: SportKey;
+    setActiveSport: (sport: SportKey) => void;
+}> = ({ sports, activeSport, setActiveSport }) => (
+    <div className="flex gap-2 mb-6 flex-wrap">
+        {sports.map((sport) => (
+            <button
+                key={sport}
+                onClick={() => setActiveSport(sport)}
+                className={`px-6 py-3 text-sm font-semibold rounded-xl transition-all duration-300 ${
+                    activeSport === sport
+                        ? 'bg-primary text-white shadow-lg scale-105'
+                        : 'bg-secondary-background text-text-primary hover:bg-secondary hover:scale-102'
+                }`}
+            >
+                {sport}
+            </button>
+        ))}
+    </div>
+);
+
+const StreakIndicator: React.FC<{ streak: string | number | null | undefined }> = ({ streak }) => {
+    if (!streak) return null;
+    
+    // Convert to string if it's not already
+    const streakStr = String(streak);
+    const isWinStreak = streakStr.startsWith('W');
+    const isLoseStreak = streakStr.startsWith('L');
+    
+    return (
+        <span className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-bold ${
+            isWinStreak ? 'bg-green-500/20 text-green-400' :
+            isLoseStreak ? 'bg-red-500/20 text-red-400' :
+            'bg-gray-500/20 text-gray-400'
+        }`}>
+            {isWinStreak && <TrendingUp size={12} />}
+            {isLoseStreak && <TrendingDown size={12} />}
+            {!isWinStreak && !isLoseStreak && <Minus size={12} />}
+            {streakStr}
+        </span>
+    );
+};
+
+const NBAStandingsDisplay: React.FC<{ standings: { eastern_conference: NBATeam[], western_conference: NBATeam[] } }> = ({ standings }) => {
+    const renderConference = (teams: NBATeam[], conferenceName: string) => {
+        // Determine playoff cutoff (typically top 10 teams make playoffs, top 6 automatic, 7-10 play-in)
+        const playoffCutoff = 6;
+        const playInCutoff = 10;
+        
+        return (
+            <div className="mb-8">
+                <div className="flex items-center gap-3 mb-4">
+                    <h3 className="text-2xl font-bold text-text-primary">{conferenceName}</h3>
+                    <div className="h-1 flex-grow bg-gradient-to-r from-primary to-transparent rounded"></div>
+                </div>
+                <div className="bg-secondary-background rounded-xl overflow-hidden shadow-lg">
+                    <div className="overflow-x-auto">
+                        <table className="w-full min-w-[800px]">
+                            <thead className="bg-secondary text-text-secondary">
+                                <tr>
+                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">#</th>
+                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Team</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">W</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">L</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">PCT</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">GB</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider hidden md:table-cell">Home</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider hidden md:table-cell">Away</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider hidden lg:table-cell">L10</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">Streak</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-secondary">
+                                {teams.map((team, idx) => {
+                                    const isPlayoffTeam = idx < playoffCutoff;
+                                    const isPlayInTeam = idx >= playoffCutoff && idx < playInCutoff;
+                                    
+                                    return (
+                                        <tr 
+                                            key={team.team_id} 
+                                            className={`hover:bg-secondary transition-colors ${
+                                                isPlayoffTeam ? 'border-l-4 border-l-green-500' :
+                                                isPlayInTeam ? 'border-l-4 border-l-yellow-500' : ''
+                                            }`}
+                                        >
+                                            <td className="px-4 py-4 text-center">
+                                                <div className="flex items-center gap-2">
+                                                    {isPlayoffTeam && <Trophy size={16} className="text-green-500" />}
+                                                    <span className="font-bold text-text-primary">{idx + 1}</span>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-4">
+                                                <div className="flex items-center gap-3">
+                                                    {team.team_logo && (
+                                                        <img src={team.team_logo} alt={`${team.team_city} ${team.team_name}`} className="w-8 h-8 object-contain" />
+                                                    )}
+                                                    <div>
+                                                        <div className="font-semibold text-text-primary">{team.team_city} {team.team_name}</div>
+                                                        <div className="text-xs text-text-secondary">{team.division}</div>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-4 text-center font-bold text-green-400">{team.wins}</td>
+                                            <td className="px-4 py-4 text-center font-bold text-red-400">{team.losses}</td>
+                                            <td className="px-4 py-4 text-center text-text-primary font-semibold">{team.win_pct.toFixed(3)}</td>
+                                            <td className="px-4 py-4 text-center text-text-secondary">{team.games_back || '-'}</td>
+                                            <td className="px-4 py-4 text-center text-text-secondary text-sm hidden md:table-cell">{team.home_record}</td>
+                                            <td className="px-4 py-4 text-center text-text-secondary text-sm hidden md:table-cell">{team.road_record}</td>
+                                            <td className="px-4 py-4 text-center text-text-secondary text-sm hidden lg:table-cell">{team.last_10}</td>
+                                            <td className="px-4 py-4 text-center">
+                                                <StreakIndicator streak={team.streak} />
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                
+                {/* Playoff Legend */}
+                <div className="flex flex-wrap gap-4 mt-4 text-sm">
+                    <div className="flex items-center gap-2">
+                        <div className="w-4 h-4 bg-green-500 rounded"></div>
+                        <span className="text-text-secondary">Playoff Teams (1-6)</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <div className="w-4 h-4 bg-yellow-500 rounded"></div>
+                        <span className="text-text-secondary">Play-In Teams (7-10)</span>
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <div>
+            {renderConference(standings.eastern_conference, "Eastern Conference")}
+            {renderConference(standings.western_conference, "Western Conference")}
+        </div>
+    );
+};
+
+const NFLStandingsDisplay: React.FC<{ standings: { afc_standings: NFLTeam[], nfc_standings: NFLTeam[] } }> = ({ standings }) => {
+    const renderConference = (teams: NFLTeam[], conferenceName: string) => {
+        if (!teams || teams.length === 0) {
+            return (
+                <div className="mb-8">
+                    <div className="flex items-center gap-3 mb-4">
+                        <h3 className="text-2xl font-bold text-text-primary">{conferenceName}</h3>
+                        <div className="h-1 flex-grow bg-gradient-to-r from-primary to-transparent rounded"></div>
+                    </div>
+                    <div className="bg-secondary-background rounded-xl p-8 text-center">
+                        <p className="text-text-secondary">No {conferenceName} standings data available</p>
+                    </div>
+                </div>
+            );
+        }
+        
+        // Sort teams by wins and win percentage
+        const sortedTeams = [...teams].sort((a, b) => {
+            if (b.wins !== a.wins) return b.wins - a.wins;
+            return b.win_pct - a.win_pct;
+        });
+        
+        // Top 7 teams make playoffs
+        const playoffTeams = sortedTeams.slice(0, 7);
+        
+        return (
+            <div className="mb-12">
+                <div className="flex items-center gap-3 mb-6">
+                    <h3 className="text-2xl font-bold text-text-primary">{conferenceName}</h3>
+                    <div className="h-1 flex-grow bg-gradient-to-r from-primary to-transparent rounded"></div>
+                </div>
+                
+                <div className="bg-secondary-background rounded-xl overflow-hidden shadow-lg border border-secondary">
+                    <div className="overflow-x-auto">
+                        <table className="w-full min-w-[800px]">
+                            <thead className="bg-secondary text-text-secondary">
+                                <tr>
+                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">#</th>
+                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Team</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">W</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">L</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">T</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">PCT</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider hidden md:table-cell">PF</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider hidden md:table-cell">PA</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider hidden lg:table-cell">Diff</th>
+                                    <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">Streak</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-secondary">
+                                {sortedTeams.map((team, idx) => {
+                                    const isPlayoffTeam = idx < 7;
+                                    
+                                    return (
+                                        <tr 
+                                            key={team.team_id}
+                                            className={`hover:bg-secondary transition-colors ${
+                                                isPlayoffTeam ? 'border-l-4 border-l-green-500' : ''
+                                            }`}
+                                        >
+                                            <td className="px-4 py-4 text-center">
+                                                <div className="flex items-center gap-2 justify-center">
+                                                    {isPlayoffTeam && <Trophy size={16} className="text-green-500" />}
+                                                    <span className={`font-bold ${isPlayoffTeam ? 'text-green-500' : 'text-text-secondary'}`}>
+                                                        {idx + 1}
+                                                    </span>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-4">
+                                                <div className="flex items-center gap-3">
+                                                    {team.team_logo && (
+                                                        <img src={team.team_logo} alt={team.team_name} className="w-8 h-8 object-contain" />
+                                                    )}
+                                                    <div>
+                                                        <div className="font-semibold text-text-primary">
+                                                            {team.team_name}
+                                                        </div>
+                                                        <div className="text-xs text-text-secondary">{team.team_abbreviation}</div>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-4 text-center font-bold text-green-400">{team.wins}</td>
+                                            <td className="px-4 py-4 text-center font-bold text-red-400">{team.losses}</td>
+                                            <td className="px-4 py-4 text-center text-text-secondary">{team.ties}</td>
+                                            <td className="px-4 py-4 text-center text-text-primary font-semibold">{team.win_pct.toFixed(3)}</td>
+                                            <td className="px-4 py-4 text-center text-text-secondary text-sm hidden md:table-cell">{team.points_for}</td>
+                                            <td className="px-4 py-4 text-center text-text-secondary text-sm hidden md:table-cell">{team.points_against}</td>
+                                            <td className={`px-4 py-4 text-center font-semibold hidden lg:table-cell ${team.point_differential > 0 ? 'text-green-400' : 'text-red-400'}`}>
+                                                {team.point_differential > 0 ? '+' : ''}{team.point_differential}
+                                            </td>
+                                            <td className="px-4 py-4 text-center">
+                                                <StreakIndicator streak={team.streak} />
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                
+                {/* Playoff Legend */}
+                <div className="flex flex-wrap gap-4 mt-4 text-sm">
+                    <div className="flex items-center gap-2">
+                        <div className="w-4 h-4 bg-green-500 rounded"></div>
+                        <span className="text-text-secondary">Playoff Teams (Top 7)</span>
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <div>
+            {renderConference(standings.afc_standings, "AFC")}
+            {renderConference(standings.nfc_standings, "NFC")}
+        </div>
+    );
+};
+
+const SoccerStandingsDisplay: React.FC<{ standings: SoccerTeam[], league: string }> = ({ standings, league }) => {
+    return (
+        <div>
+            <div className="flex items-center gap-3 mb-4">
+                <h3 className="text-2xl font-bold text-text-primary">{league} Standings</h3>
+                <div className="h-1 flex-grow bg-gradient-to-r from-primary to-transparent rounded"></div>
+            </div>
+            
+            <div className="bg-secondary-background rounded-xl overflow-hidden shadow-lg">
+                <div className="overflow-x-auto">
+                    <table className="w-full min-w-[700px]">
+                        <thead className="bg-secondary text-text-secondary">
+                            <tr>
+                                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">#</th>
+                                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Team</th>
+                                <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">GP</th>
+                                <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">W</th>
+                                <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">D</th>
+                                <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">L</th>
+                                <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider hidden md:table-cell">GF</th>
+                                <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider hidden md:table-cell">GA</th>
+                                <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">GD</th>
+                                <th className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider">PTS</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-secondary">
+                            {standings.map((team, idx) => (
+                                <tr key={team.team_id} className="hover:bg-secondary transition-colors">
+                                    <td className="px-4 py-4">
+                                        <span className="font-bold text-text-primary">{idx + 1}</span>
+                                    </td>
+                                    <td className="px-4 py-4">
+                                        <div className="flex items-center gap-3">
+                                            {team.team_logo && (
+                                                <img src={team.team_logo} alt={team.team_name} className="w-8 h-8 object-contain" />
+                                            )}
+                                            <div>
+                                                <div className="font-semibold text-text-primary">{team.team_name}</div>
+                                                {team.group && <div className="text-xs text-text-secondary">{team.group}</div>}
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td className="px-4 py-4 text-center text-text-secondary">{team.games_played}</td>
+                                    <td className="px-4 py-4 text-center font-bold text-green-400">{team.wins}</td>
+                                    <td className="px-4 py-4 text-center font-bold text-yellow-400">{team.draws}</td>
+                                    <td className="px-4 py-4 text-center font-bold text-red-400">{team.losses}</td>
+                                    <td className="px-4 py-4 text-center text-text-secondary hidden md:table-cell">{team.goals_for}</td>
+                                    <td className="px-4 py-4 text-center text-text-secondary hidden md:table-cell">{team.goals_against}</td>
+                                    <td className="px-4 py-4 text-center">
+                                        <span className={`font-semibold ${team.goal_differential > 0 ? 'text-green-400' : team.goal_differential < 0 ? 'text-red-400' : 'text-text-secondary'}`}>
+                                            {team.goal_differential > 0 ? '+' : ''}{team.goal_differential}
+                                        </span>
+                                    </td>
+                                    <td className="px-4 py-4 text-center">
+                                        <span className="font-bold text-lg text-primary">{team.points}</span>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default function StandingsPage() {
+    const sports: SportKey[] = ['NBA', 'NFL', 'MLS'];
+    const [activeSport, setActiveSport] = useState<SportKey>('NBA');
+    const [nbaStandings, setNbaStandings] = useState<{ eastern_conference: NBATeam[], western_conference: NBATeam[] } | null>(null);
+    const [nflStandings, setNflStandings] = useState<{ afc_standings: NFLTeam[], nfc_standings: NFLTeam[] } | null>(null);
+    const [soccerStandings, setSoccerStandings] = useState<{ standings: SoccerTeam[] } | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchStandings = async () => {
+            setLoading(true);
+            setError(null);
+            
+            try {
+                if (activeSport === 'NBA' && !nbaStandings) {
+                    const data = await getNBAStandings();
+                    console.log('NBA Standings Data:', data);
+                    setNbaStandings(data);
+                } else if (activeSport === 'NFL' && !nflStandings) {
+                    const data = await getNFLStandings();
+                    console.log('NFL Standings Data:', data);
+                    if (data.error) {
+                        setError(`NFL API Error: ${data.error}`);
+                    } else if (!data.afc_standings || data.afc_standings.length === 0) {
+                        setError('No NFL standings data available. The API may be temporarily unavailable.');
+                    } else {
+                        setNflStandings(data);
+                    }
+                } else if (activeSport === 'MLS' && !soccerStandings) {
+                    const data = await getSoccerStandings('MLS');
+                    console.log('Soccer Standings Data:', data);
+                    setSoccerStandings(data);
+                }
+            } catch (err) {
+                setError(`Failed to load ${activeSport} standings. Please try again later.`);
+                console.error(err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchStandings();
+    }, [activeSport, nbaStandings, nflStandings, soccerStandings]);
+
+    return (
+        <div className="min-h-screen">
+            <div className="mb-8">
+                <div className="flex items-center gap-4 mb-4">
+                    <Trophy className="text-primary" size={40} />
+                    <div>
+                        <h1 className="text-4xl font-bold text-text-primary">League Standings</h1>
+                        <p className="text-text-secondary mt-1">Current standings and playoff positions</p>
+                    </div>
+                </div>
+            </div>
+
+            <SportsFilter sports={sports} activeSport={activeSport} setActiveSport={setActiveSport} />
+
+            {loading && (
+                <div className="flex justify-center items-center py-20">
+                    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
+                </div>
+            )}
+
+            {error && (
+                <div className="bg-red-500/10 border border-red-500 rounded-xl p-6 text-center">
+                    <p className="text-red-400 font-semibold">{error}</p>
+                </div>
+            )}
+
+            {!loading && !error && (
+                <>
+                    {activeSport === 'NBA' && nbaStandings && (
+                        <NBAStandingsDisplay standings={nbaStandings} />
+                    )}
+                    {activeSport === 'NFL' && nflStandings && (
+                        <NFLStandingsDisplay standings={nflStandings} />
+                    )}
+                    {activeSport === 'MLS' && soccerStandings && (
+                        <SoccerStandingsDisplay standings={soccerStandings.standings} league="MLS" />
+                    )}
+                </>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/backend_methods/helpers/backend_routing.tsx
+++ b/frontend/src/backend_methods/helpers/backend_routing.tsx
@@ -74,16 +74,19 @@ export const ROUTES = {
     specific_nba_game_boxscore: (gameId: string) => `${BASE_URL}/nba/game/${gameId}/boxscore`,
     specific_nba_team_last_game: (teamId: string) => `${BASE_URL}/nba/teams/${teamId}/last`,
     upcoming_nba_games: `${BASE_URL}/nba/upcoming`,
+    nba_standings: `${BASE_URL}/nba/standings`,
     
     nfl_games: `${BASE_URL}/nfl/games`,
     specific_nfl_game_details: (gameId: string) => `${BASE_URL}/nfl/game/${gameId}`,
     specific_nfl_game_boxscore: (gameId: string) => `${BASE_URL}/nfl/game/${gameId}/boxscore`,
     upcoming_nfl_games: `${BASE_URL}/nfl/upcoming`,
+    nfl_standings: `${BASE_URL}/nfl/standings`,
     
     soccer_matches: `${BASE_URL}/soccer/matches`,
     specific_soccer_match_details: (matchId: string) => `${BASE_URL}/soccer/game/${matchId}`,
     specific_soccer_match_boxscore: (matchId: string) => `${BASE_URL}/soccer/game/${matchId}/boxscore`,
     upcoming_soccer_matches: `${BASE_URL}/soccer/upcoming`,
+    soccer_standings: (league: string) => `${BASE_URL}/soccer/standings?league=${league}`,
 };
 
 //method to make a post or get request to the backend using axiom

--- a/frontend/src/backend_methods/standings_methods.tsx
+++ b/frontend/src/backend_methods/standings_methods.tsx
@@ -1,0 +1,42 @@
+/*
+File: standings_methods.tsx
+Description: This file contains the methods to make requests to the backend for standings data across different sports.
+*/
+
+import { ROUTES, makeBackendRequest, checkBackendHealth } from "./helpers/backend_routing";
+
+export const getNBAStandings = async (season?: string) => {
+    try {
+        await checkBackendHealth();
+        const url = season ? `${ROUTES.nba_standings}?season=${season}` : ROUTES.nba_standings;
+        return makeBackendRequest('GET', url);
+    } catch (error) {
+        console.error("Error fetching NBA standings:", error);
+        throw error;
+    }
+};
+
+export const getNFLStandings = async (season?: string) => {
+    try {
+        await checkBackendHealth();
+        const url = season ? `${ROUTES.nfl_standings}?season=${season}` : ROUTES.nfl_standings;
+        return makeBackendRequest('GET', url);
+    } catch (error) {
+        console.error("Error fetching NFL standings:", error);
+        throw error;
+    }
+};
+
+export const getSoccerStandings = async (league: string = "MLS", season?: string) => {
+    try {
+        await checkBackendHealth();
+        let url = ROUTES.soccer_standings(league);
+        if (season) {
+            url += `&season=${season}`;
+        }
+        return makeBackendRequest('GET', url);
+    } catch (error) {
+        console.error(`Error fetching ${league} standings:`, error);
+        throw error;
+    }
+};

--- a/frontend/src/components/DashboardComponents/MainDashboardComponents/Sidebar.tsx
+++ b/frontend/src/components/DashboardComponents/MainDashboardComponents/Sidebar.tsx
@@ -9,7 +9,7 @@
 */
 "use client"
 import { ThemeToggle } from "@/components/ui/ThemeToggle"
-import { Home, ChartScatter, AlignJustify, X, Trophy } from "lucide-react"
+import { Home, ChartScatter, AlignJustify, X, Trophy, Award } from "lucide-react"
 import { usePathname } from "next/navigation"
 import Link from "next/link"
 import { useState } from "react"
@@ -30,6 +30,11 @@ const navItems = [
         title: 'Team Comparisons',
         href: '/team-comparisons',
         icon: Trophy,
+    },
+    {
+        title: 'Standings',
+        href: '/standings',
+        icon: Award,
     }
 ]
 


### PR DESCRIPTION
This pull request seeks to add a Page to display the current standings for all the teams in tall of the various leagues. 

To test this, checkout the "Standings-Page" branch, and run the frontend and backend servers. Then navigate to the 
<img width="46" height="54" alt="image" src="https://github.com/user-attachments/assets/b4520a92-56a0-4f2b-a701-ca6f570d7aa6" />

then you can view the different leagues and their standings here

<img width="1467" height="910" alt="image" src="https://github.com/user-attachments/assets/aacd72af-a794-4a22-892f-b9795a658629" />
